### PR TITLE
Add docker-compose for all in one

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,25 @@ This is an extension of [Cadence service](https://github.com/uber/cadence) to su
 
 See detailed background and proposal in this [issue](https://github.com/uber/cadence/issues/3798).
 
-Running locally
+Running locally with docker-compose
 ---
-TODO: add a Dockerfile to build docker image, then make a docker-compose file to run all in one
+Run below command to start local all-in-one docker
+```
+cd docker/ && docker-compose up 
+```
+Wait for a few seconds to let everything get stable (no logs rolling).
+
+Then checkout [cadence-samples](https://github.com/uber-common/cadence-samples) to run a helloworld
+```
+cadence --do samples-domain d re && ./bin/helloworld && ./bin/helloworld -m worker
+```  
+
+You will see the test receiver can receive some messages in the logs:
+```
+cadence-notification_1  | 2022/04/07 04:23:06 [Test server incoming request]: &{0-1  2cab9b7e-40bb-45e2-8438-2c99454f7eaf helloworld_7d1d74ea-4e39-494f-a9cc-7151604ab14a 851dc419-f028-49fa-b10f-9f3d70022d7a main.helloWorldWorkflow 52264409061-03-05 22:26:40 +0000 UTC 1970-01-01 00:00:00 +0000 UTC 1970-01-01 00:00:00 +0000 UTC map[BinaryChecksums:[bb2814702ff3d6522c5b6849d9ade58e] ExecutionTime:0 IsCron:false NumClusters:1 StartTime:1649305385884708000 TaskList:helloWorldGroup WorkflowType:main.helloWorldWorkflow] map[]}, URL: /
+cadence-notification_1  | 2022/04/07 04:23:06 [Test server incoming request]: &{0-2  2cab9b7e-40bb-45e2-8438-2c99454f7eaf helloworld_7d1d74ea-4e39-494f-a9cc-7151604ab14a 851dc419-f028-49fa-b10f-9f3d70022d7a main.helloWorldWorkflow 52264409061-03-05 22:26:40 +0000 UTC 1970-01-01 00:00:00 +0000 UTC 1970-01-01 00:00:00 +0000 UTC map[BinaryChecksums:[bb2814702ff3d6522c5b6849d9ade58e] CloseStatus:0 CloseTime:1649305386686346800 ExecutionTime:0 HistoryLength:11 IsCron:false NumClusters:1 StartTime:1649305385884708000 TaskList:helloWorldGroup WorkflowType:main.helloWorldWorkflow] map[]}, URL: /
+
+```
 
 Running in Production
 ---

--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -197,7 +197,8 @@ func startTestWebhookEndpoint() {
 	http.HandleFunc("/", logIncomingRequest)
 
 	fmt.Printf("Starting server for testing...\n")
-	if err := http.ListenAndServe(":8081", nil); err != nil {
+	// TODO make test webhook endpoint port configurable
+	if err := http.ListenAndServe(":8801", nil); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -10,7 +10,7 @@ service:
         webhook:
           url:
             scheme: {{ default .Env.WEBHOOK_SHCEME "HTTP" }}
-            host: {{ default .Env.WEBHOOK_URL "127.0.0.1:8810" }}
+            host: {{default .Env.WEBHOOK_URL "127.0.0.1:8801"}}
           retryInterval: 10s # default to 1s
       consumer:
         consumerGroup: cadence-notificationAppA-group

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -7,7 +7,7 @@ service:
         webhook:
           url:
             scheme: "http"
-            host: "127.0.0.1:8810"
+            host: "127.0.0.1:8801"
           retryInterval: 10s # default to 1s
       consumer:
         consumerGroup: cadence-notificationAppA-group

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+version: '3'
+services:
+  cassandra:
+    image: cassandra:3.11
+    ports:
+      - "9042:9042"
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus_config.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - '9090:9090'
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.12-2.1.1
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3
+    ports:
+      - "9200:9200"
+    environment:
+      - discovery.type=single-node
+  cadence:
+    image: ubercadence/server:master-auto-setup
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+      - "8002:8002"
+      - "8003:8003"
+      - "7933:7933"
+      - "7934:7934"
+      - "7935:7935"
+      - "7939:7939"
+      - "7833:7833"
+    environment:
+      - "CASSANDRA_SEEDS=cassandra"
+      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:8000"
+      - "PROMETHEUS_ENDPOINT_1=0.0.0.0:8001"
+      - "PROMETHEUS_ENDPOINT_2=0.0.0.0:8002"
+      - "PROMETHEUS_ENDPOINT_3=0.0.0.0:8003"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
+      - "ENABLE_ES=true"
+      - "ES_SEEDS=elasticsearch"
+      - "ES_VERSION=v7"
+      - "KAFKA_SEEDS=kafka"
+    depends_on:
+      - cassandra
+      - prometheus
+      - kafka
+      - elasticsearch
+  cadence-web:
+    image: ubercadence/web:latest
+    environment:
+      - "CADENCE_TCHANNEL_PEERS=cadence:7933"
+    ports:
+      - "8088:8088"
+    depends_on:
+      - cadence
+  grafana:
+    image: grafana/grafana
+    user: "1000"
+    depends_on:
+      - prometheus
+    ports:
+      - '3000:3000'
+  cadence-notification:
+    image: ubercadence/cadence-notification:0.0.1
+    depends_on:
+      - cadence
+    ports:
+      - '3000:3000'
+    environment:
+      - "KAFKA_SEEDS=kafka"
+      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:8004"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     volumes:
-      - ./prometheus_config.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus:/etc/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
@@ -79,8 +79,6 @@ services:
     image: ubercadence/cadence-notification:0.0.1
     depends_on:
       - cadence
-    ports:
-      - '3000:3000'
     environment:
       - "KAFKA_SEEDS=kafka"
       - "PROMETHEUS_ENDPOINT_0=0.0.0.0:8004"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     ports:
       - '3000:3000'
   cadence-notification:
-    image: ubercadence/cadence-notification:0.0.1
+    image: ubercadence/cadence-notification:0.0.2
     depends_on:
       - cadence
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -79,6 +79,10 @@ services:
     image: ubercadence/cadence-notification:0.0.2
     depends_on:
       - cadence
+      - kafka
+      - zookeeper
+      - elasticsearch
+      - prometheus
     environment:
       - "KAFKA_SEEDS=kafka"
       - "PROMETHEUS_ENDPOINT_0=0.0.0.0:8004"

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 5s
+  external_labels:
+    monitor: 'cadence-monitor'
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: # addresses to scrape
+          - 'cadence:9090'
+          - 'cadence:8000'
+          - 'cadence:8001'
+          - 'cadence:8002'
+          - 'cadence:8003'

--- a/start.sh
+++ b/start.sh
@@ -6,5 +6,9 @@ CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence-notification/config/c
 
 dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence-notification/config/docker.yaml
 
+# TODO https://github.com/cadence-oss/cadence-notification/issues/23
+# depends_on in docker-compose doesn't work and the startup will fail at waiting for Kafka to be up.
+# waiting for 5 second here can mitigate it.
+sleep 5
 exec cadence-notification --root $CADENCE_NOTIFICATION_HOME --env docker start --services=$SERVICES
 


### PR DESCRIPTION
verified:
```
cadence_1               | {"level":"info","ts":"2022-04-07T04:23:06.479Z","msg":"this is the very first itemID being read in this ackManager","service":"cadence-worker","kafka-partition":0,"queue-task-id":1,"logging-call-at":"ackManager.go:83"}
cadence-notification_1  | 2022/04/07 04:23:06 [Test server incoming request]: &{0-1  2cab9b7e-40bb-45e2-8438-2c99454f7eaf helloworld_7d1d74ea-4e39-494f-a9cc-7151604ab14a 851dc419-f028-49fa-b10f-9f3d70022d7a main.helloWorldWorkflow 52264409061-03-05 22:26:40 +0000 UTC 1970-01-01 00:00:00 +0000 UTC 1970-01-01 00:00:00 +0000 UTC map[BinaryChecksums:[bb2814702ff3d6522c5b6849d9ade58e] ExecutionTime:0 IsCron:false NumClusters:1 StartTime:1649305385884708000 TaskList:helloWorldGroup WorkflowType:main.helloWorldWorkflow] map[]}, URL: /
cadence_1               | {"level":"info","ts":"2022-04-07T04:23:06.527Z","msg":"First loading dynamic config","service":"cadence-history","key":"history.stickyTTL,domainName:samples-domain,clusterName:primary","value":"8760h0m0s","default-value":"8760h0m0s","logging-call-at":"config.go:93"}
elasticsearch_1         | {"type": "deprecation", "timestamp": "2022-04-07T04:23:06,600Z", "level": "WARN", "component": "o.e.d.a.b.BulkRequestParser", "cluster.name": "docker-cluster", "node.name": "ad7b8a1e0c4f", "message": "[types removal] Specifying types in bulk requests is deprecated.", "cluster.uuid": "a5UuGsQKT_W7dqKFIZNQMg", "node.id": "FlQpWfhPRm-EBzQNDwEt6Q"  }
cadence_1               | {"level":"info","ts":"2022-04-07T04:23:06.719Z","msg":"First loading dynamic config","service":"cadence-history","key":"system.enableParentClosePolicyWorker,clusterName:primary","value":"true","default-value":"true","logging-call-at":"config.go:93"}
cadence_1               | {"level":"info","ts":"2022-04-07T04:23:06.719Z","msg":"First loading dynamic config","service":"cadence-history","key":"history.parentClosePolicyThreshold,domainName:samples-domain,clusterName:primary","value":"10","default-value":"10","logging-call-at":"config.go:93"}
cadence-notification_1  | 2022/04/07 04:23:06 [Test server incoming request]: &{0-2  2cab9b7e-40bb-45e2-8438-2c99454f7eaf helloworld_7d1d74ea-4e39-494f-a9cc-7151604ab14a 851dc419-f028-49fa-b10f-9f3d70022d7a main.helloWorldWorkflow 52264409061-03-05 22:26:40 +0000 UTC 1970-01-01 00:00:00 +0000 UTC 1970-01-01 00:00:00 +0000 UTC map[BinaryChecksums:[bb2814702ff3d6522c5b6849d9ade58e] CloseStatus:0 CloseTime:1649305386686346800 ExecutionTime:0 HistoryLength:11 IsCron:false NumClusters:1 StartTime:1649305385884708000 TaskList:helloWorldGroup WorkflowType:main.helloWorldWorkflow] map[]}, URL: /
```