### PR TITLE
feat: make test webhook endpoint port configurable

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -80,6 +80,10 @@ func getConfigDir(c *cli.Context) string {
 	return constructPathIfNeed(getRootDir(c), c.GlobalString("config"))
 }
 
+func getReceiverAddress(c *cli.Context) string {
+	return strings.TrimSpace(c.GlobalString("receiver_address"))
+}
+
 func getRootDir(c *cli.Context) string {
 	dirpath := c.GlobalString("root")
 	if len(dirpath) == 0 {
@@ -133,6 +137,12 @@ func BuildCLI() *cli.App {
 			Usage:  "availability zone",
 			EnvVar: cconfig.EnvKeyAvailabilityZone,
 		},
+		cli.StringFlag{
+			Name: "receiver_address, ra",
+			Value: ":8801",
+			Usage: "receiver address",
+			EnvVar: config.EnvKeyReceiverAddress,
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -169,7 +179,7 @@ func launchService(service string, c *cli.Context) {
 		startHandler(c)
 		break
 	case "receiver":
-		startTestWebhookEndpoint()
+		startTestWebhookEndpoint(c)
 		break
 	default:
 		log.Printf("Invalid service: %v", service)
@@ -193,12 +203,12 @@ func getServices(c *cli.Context) []string {
 	return services
 }
 
-func startTestWebhookEndpoint() {
+func startTestWebhookEndpoint(c *cli.Context) {
+	addr := getReceiverAddress(c)
 	http.HandleFunc("/", logIncomingRequest)
 
-	fmt.Printf("Starting server for testing...\n")
-	// TODO make test webhook endpoint port configurable
-	if err := http.ListenAndServe(":8801", nil); err != nil {
+	fmt.Printf("Starting server %s for testing...\n", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/common/config/Config.go
+++ b/common/config/Config.go
@@ -28,6 +28,10 @@ import (
 	cconfig "github.com/uber/cadence/common/config"
 )
 
+const (
+	EnvKeyReceiverAddress = "RECEIVER_ADDRESS"
+)
+
 type (
 	// Config contains the configuration for a set of cadence services
 	Config struct {


### PR DESCRIPTION
#22 

Maybe using config file WEBHOOK_URL much better?
But for http server address 0.0.0.0 much better than 127.0.0.1 or localhost.